### PR TITLE
Add custom scopes for eps1lon/poe-mods

### DIFF
--- a/src/controller/recraft.js
+++ b/src/controller/recraft.js
@@ -204,8 +204,6 @@ const formatEssence = essence => {
   };
 };
 
-const formatEssenceForMods = formatEssence;
-
 const formatGrantedEffect = effect => {
   const { id, is_support, cast_time, granted_effects_per_levels } = effect;
 
@@ -282,12 +280,7 @@ module.exports = models => async (req, res, next) => {
           models.Essence.withMods(essences, models.Mod, formatMod, attribute =>
             attribute.replace('_mods_key', '_mod'),
           ),
-        )
-        .then(essences => {
-          return essences.map(essence => {
-            return formatEssenceForMods(essence);
-          });
-        }),
+        ),
     gems: () =>
       models.SkillGem
         .scope('for-recraft')

--- a/src/models/scope/BaseItemType.js
+++ b/src/models/scope/BaseItemType.js
@@ -118,5 +118,66 @@ module.exports = models => {
         },
       },
     },
+    // structure for eps1lon/reacraft
+    'for-poe-mods': {
+      attributes: [
+        'id',
+        'inherits_from',
+        'name',
+        'width',
+        'height',
+        'drop_level',
+        'item_classes_key',
+      ],
+      include: [
+        {
+          model: models.ItemClass,
+          attributes: ['id'],
+          as: 'item_class',
+        },
+        {
+          model: models.ComponentArmour,
+          as: 'component_armour',
+          attributes: ['armour', 'evasion', 'energy_shield'],
+        },
+        {
+          model: models.ComponentAttributeRequirement,
+          as: 'component_attribute_requirements',
+          attributes: ['req_str', 'req_dex', 'req_int'],
+        },
+        {
+          model: models.WeaponType,
+          as: 'weapon_type',
+          attributes: [
+            'critical',
+            'speed',
+            'damage_min',
+            'damage_max',
+            'range_max',
+          ],
+        },
+        {
+          model: models.Tag,
+          as: 'tags',
+          attributes: ['id'],
+        },
+        {
+          model: models.Mod,
+          as: 'implicit_mods',
+          ...mod_scope['for-poe-mods'],
+        },
+        {
+          model: models.ShieldType,
+          as: 'shield_type',
+          attributes: ['block'],
+        },
+      ],
+      where: {
+        item_classes_key: {
+          // mtx
+          $notIn: [40],
+        },
+      },
+    },
   };
 };

--- a/src/models/scope/CraftingBenchOption.js
+++ b/src/models/scope/CraftingBenchOption.js
@@ -99,5 +99,54 @@ module.exports = models => {
         },
       ],
     },
+    // data structure for eps1lon/poe_mod_repository
+    'for-poe-mods': {
+      attributes: [
+        ['row', 'primary'],
+        'order',
+        'master_level',
+        'name',
+        'crafting_bench_custom_action',
+        'sockets',
+        'socket_colours',
+        'links',
+        'item_quantity',
+        // include only
+        'npc_master_key',
+        'mods_key',
+      ],
+      include: [
+        {
+          model: models.BaseItemType,
+          as: 'cost_base_item_types',
+          through: {
+            attributes: ['value', 'priority'],
+          },
+          ...base_item_type_scope['for-poe-mods'],
+        },
+        {
+          model: models.NPCMaster,
+          as: 'npc_master',
+          attributes: ['row'],
+          include: [
+            {
+              model: models.NPC,
+              as: 'npc',
+              attributes: ['name', 'short_name'],
+            },
+          ],
+        },
+        {
+          model: models.ItemClass,
+          as: 'item_classes',
+          attributes: ['id'],
+        },
+        {
+          model: models.Mod,
+          as: 'mod',
+          ...mod_scope['for-poe-mods'],
+        },
+      ],
+    },
   };
 };

--- a/src/models/scope/Essence.js
+++ b/src/models/scope/Essence.js
@@ -98,7 +98,7 @@ module.exports = models => {
         {
           model: models.BaseItemType,
           as: 'base_item_type',
-          ...base_item_type_scope['for-recraft'],
+          ...base_item_type_scope['for-poe-mods'],
         },
         {
           model: models.EssenceType,

--- a/src/models/scope/Mod.js
+++ b/src/models/scope/Mod.js
@@ -68,7 +68,7 @@ module.exports = models => {
         },
       ],
     },
-    // data structure for eps1lon/poe_mod_repository
+    // data structure for eps1lon/recraft
     'for-recraft': {
       attributes: [
         ['row', 'primary'],
@@ -137,6 +137,79 @@ module.exports = models => {
           as: 'tags',
           //scope: 'for-recraft',
           ...tag_scope['for-recraft'],
+        },
+        {
+          model: models.Tag,
+          as: 'spawn_weight_tags',
+          ...tag_scope['for-recraft'],
+          through: {
+            attributes: ['value', 'priority'],
+          },
+        },
+      ],
+    },
+    // data structure for eps1lon/poe-mods
+    'for-poe-mods': {
+      attributes: [
+        'id',
+        'level',
+        'domain',
+        'name',
+        'generation_type',
+        'correct_group',
+        'stat1_min',
+        'stat1_max',
+        'stat2_min',
+        'stat2_max',
+        'stat3_min',
+        'stat3_max',
+        'stat4_min',
+        'stat4_max',
+        'stat5_min',
+        'stat5_max',
+        // for include only
+        'stats_key1',
+        'stats_key2',
+        'stats_key3',
+        'stats_key4',
+        'stats_key5',
+        'mod_type_key',
+      ],
+      include: [
+        {
+          model: models.ModType,
+          as: 'mod_type',
+          attributes: [['row', 'primary']],
+        },
+        {
+          model: models.Stat,
+          as: 'stats1',
+          attributes: ['id', 'text'],
+        },
+        {
+          model: models.Stat,
+          as: 'stats2',
+          attributes: ['id', 'text'],
+        },
+        {
+          model: models.Stat,
+          as: 'stats3',
+          attributes: ['id', 'text'],
+        },
+        {
+          model: models.Stat,
+          as: 'stats4',
+          attributes: ['id', 'text'],
+        },
+        {
+          model: models.Stat,
+          as: 'stats5',
+          attributes: ['id', 'text'],
+        },
+        {
+          model: models.Tag,
+          as: 'tags',
+          attributes: ['id'],
         },
         {
           model: models.Tag,


### PR DESCRIPTION
Removes some functionality from the recraft controller that was only used by `poe-mods`.
`poe-mods` now takes care of most of the formatting.

The big join for all mods however is still only possible from within this package because of MySQL limitations.